### PR TITLE
fix: 全角英数を半角英数に置き換える

### DIFF
--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -1,0 +1,6 @@
+/** 全角英数を半角英数に置き換える */
+export const replaceFullWidthWithHalfWidth = (str: string) => {
+  return str.replace(/[Ａ-Ｚａ-ｚ０-９]/g, (s) =>
+    String.fromCharCode(s.charCodeAt(0) - 0xFEE0)
+  )
+}

--- a/src/store/data.ts
+++ b/src/store/data.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { Transaction, TransactionCategory } from '../types/transaction'
+import { replaceFullWidthWithHalfWidth } from '../lib/string'
 
 /** 仕訳に応じて収支のセルの値を選択し返す
  *
@@ -116,12 +117,12 @@ export const useDataStore = defineStore('data', () => {
             row[header.indexOf('支出')],
           ),
         ),
-        receipt: row[header.indexOf('領収書No')],
+        receipt: replaceFullWidthWithHalfWidth(row[header.indexOf('領収書No')]),
         recipient: row[header.indexOf('謝礼相手先')],
         transportPurpose: row[header.indexOf('通信運搬用途')],
         printPurpose: row[header.indexOf('印刷目的')],
         owner: row[header.indexOf('用具所有者')],
-        numStay: row[header.indexOf('延べ宿泊数')],
+        numStay: replaceFullWidthWithHalfWidth(row[header.indexOf('延べ宿泊数')]),
       }
 
       result.push(transaction)


### PR DESCRIPTION
Fixes #5

Add functionality to replace full-width alphanumeric characters with half-width ones in specified fields.

* **src/lib/string.ts**: Add a utility function `replaceFullWidthWithHalfWidth` to replace full-width alphanumeric characters with half-width ones.
* **src/store/data.ts**: Import `replaceFullWidthWithHalfWidth` from `src/lib/string.ts`. Update the `transactions` computed property to use `replaceFullWidthWithHalfWidth` for the specified fields: receipt number and total number of nights stayed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tsukuba-neu/sawagani/pull/6?shareId=bc3914eb-fb62-44ee-865c-055a544f60fd).