### PR TITLE
feat: ファイルピッカーでのインポート機能を追加

### DIFF
--- a/src/components/ControlUI.vue
+++ b/src/components/ControlUI.vue
@@ -46,7 +46,12 @@ const importFromFile = async (event: Event) => {
   const reader = new FileReader()
   reader.onload = (e) => {
     const text = (e.target?.result as string) || ''
-    dataStore.importCSVString(text)
+    try {
+      dataStore.importCSVString(text)
+    } catch (error) {
+      alert('ファイルを正しく読み取ることができませんでした。正しいファイルが選択されているか確認してください。');
+      console.error('Error importing CSV:', error)
+    }
   }
   reader.readAsText(file)
 }

--- a/src/components/ControlUI.vue
+++ b/src/components/ControlUI.vue
@@ -6,6 +6,7 @@
       <template #loading>クリップボードを読み取り中……</template>
       <template #completed>クリップボードからインポートしました</template>
     </ButtonWithState>
+    <button @click="importFromFile">ファイルからインポート</button>
     <button
       @click="
         confirm('リセットすると入力中のすべてのデータが破棄されます。') &&
@@ -35,6 +36,19 @@ const importFromClipboard = async () => {
     .filter((line) => line.length > 0 && line.match(/\S/))
     .map((line) => line.split('\t'))
   book.value = b
+}
+
+const importFromFile = async (event: Event) => {
+  const input = event.target as HTMLInputElement
+  if (!input.files?.length) return
+
+  const file = input.files[0]
+  const reader = new FileReader()
+  reader.onload = (e) => {
+    const text = (e.target?.result as string) || ''
+    dataStore.importCSVString(text)
+  }
+  reader.readAsText(file)
 }
 </script>
 

--- a/src/components/DragDropImporter.vue
+++ b/src/components/DragDropImporter.vue
@@ -5,10 +5,8 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useDataStore } from '../store/data'
-import { storeToRefs } from 'pinia'
 
 const dataStore = useDataStore()
-const { book } = storeToRefs(dataStore)
 
 const isDragging = ref(false)
 

--- a/src/components/DragDropImporter.vue
+++ b/src/components/DragDropImporter.vue
@@ -6,7 +6,6 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useDataStore } from '../store/data'
 import { storeToRefs } from 'pinia'
-import { parse as parseCSV } from 'papaparse'
 
 const dataStore = useDataStore()
 const { book } = storeToRefs(dataStore)
@@ -27,8 +26,7 @@ const onDrop = (e: DragEvent) => {
     const reader = new FileReader()
     reader.addEventListener('load', (e) => {
       const text = e.target?.result as string
-      const { data } = parseCSV<string[]>(text)
-      book.value = data
+      dataStore.importCSVString(text)
     })
     reader.readAsText(files[0])
   }

--- a/src/store/data.ts
+++ b/src/store/data.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { Transaction, TransactionCategory } from '../types/transaction'
 import { replaceFullWidthWithHalfWidth } from '../lib/string'
+import { parse as parseCSV } from 'papaparse'
 
 /** 仕訳に応じて収支のセルの値を選択し返す
  *
@@ -172,6 +173,11 @@ export const useDataStore = defineStore('data', () => {
     )
   }
 
+  const importCSVString = (csvString: string) => {
+    const { data } = parseCSV<string[]>(csvString)
+    book.value = data
+  }
+
   return {
     /** 団体名 */
     orgName,
@@ -226,5 +232,8 @@ export const useDataStore = defineStore('data', () => {
 
     /** ストアを初期状態を戻す */
     reset,
+
+    /** CSV文字列をパースしてbookに設定する */
+    importCSVString,
   }
 })


### PR DESCRIPTION
Fixes #9

Add file picker functionality for CSV import.

* Add a new button in `src/components/ControlUI.vue` for file selection and CSV import.
* Create a new method `importFromFile` in `src/components/ControlUI.vue` to handle file selection and CSV parsing.
* Update `src/store/data.ts` to include a new function `importCSVString` for centralized CSV parsing logic.
* Remove the `parseCSV` import statement from `src/components/DragDropImporter.vue` and replace the `parse` method with a call to `importCSVString`.
* Update the template in `src/components/ControlUI.vue` to include the new button and bind it to the `importFromFile` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tsukuba-neu/sawagani/pull/10?shareId=13773bc9-b4cc-4769-8c25-feb3126095d6).