### PR TITLE
fix: Firefoxでnumber inputのspinnerを隠す

### DIFF
--- a/src/components/EditableField.vue
+++ b/src/components/EditableField.vue
@@ -83,9 +83,9 @@ onMounted(() => {
 input,
 textarea {
   position: relative;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
+  -webkit-appearance: textfield;
+  -moz-appearance: textfield;
+  appearance: textfield;
   border: none;
   font-size: 1em;
   background-color: transparent;

--- a/src/components/EditableField.vue
+++ b/src/components/EditableField.vue
@@ -83,14 +83,20 @@ onMounted(() => {
 input,
 textarea {
   position: relative;
-  -webkit-appearance: textfield;
-  -moz-appearance: textfield;
-  appearance: textfield;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
   border: none;
   font-size: 1em;
   background-color: transparent;
   width: 100%;
   height: 100%;
+
+  &[type='number'] {
+    -webkit-appearance: textarea;
+    -moz-appearance: textarea;
+    appearance: textarea;
+  }
 
   &.allow-overflow {
     field-sizing: content;

--- a/src/index.html
+++ b/src/index.html
@@ -44,6 +44,7 @@
       }
       input[type='number'] {
         -moz-appearance: textfield;
+        appearance: textfield;
         &::-webkit-outer-spin-button,
         &::-webkit-inner-spin-button {
           -webkit-appearance: none;


### PR DESCRIPTION
Firefoxで数値入力欄にspinnerが表示されて表示が崩れる問題を修正します。

<img width="174" height="236" alt="image" src="https://github.com/user-attachments/assets/1b8cca3c-ee80-4846-a758-bff3edb56c6c" />
