### PR TITLE
fix: Firefoxでの預金欄の表示崩れを修正

### DIFF
--- a/src/components/SummaryTable.vue
+++ b/src/components/SummaryTable.vue
@@ -314,7 +314,7 @@
       class="border centered-v table-cell-pad"
       style="grid-row: 23; grid-column: 2"
     >
-      <span>
+      <span class="text-and-field">
         預金（<EditableField
           v-model="bank1Name"
           placeholder="サンプル銀行"
@@ -338,7 +338,7 @@
       class="border centered-v table-cell-pad"
       style="grid-row: 24; grid-column: 2"
     >
-      <span>
+      <span class="text-and-field">
         預金（<EditableField
           v-model="bank2Name"
           placeholder="サンプル銀行"
@@ -448,5 +448,12 @@ const isCarryOverMatch = computed(() => {
   display: grid;
   grid-template-columns: 20pt auto repeat(2, calc(var(--num-place-width) * 9));
   grid-template-rows: repeat(25, 28pt);
+}
+
+.text-and-field {
+  display: flex;
+  white-space: nowrap;
+  width: 100%;
+  height: 1em;
 }
 </style>


### PR DESCRIPTION
Firefoxが[`field-sizing`をサポートしていない](https://developer.mozilla.org/ja/docs/Web/CSS/Reference/Properties/field-sizing)ことによる表示崩れ（ #7 ）を修正します。

`field-sizing`をサポートしているブラウザ（Chromeなど）ではこれまで通りの表示を継続します。

Before: <img width="365" height="213" alt="image" src="https://github.com/user-attachments/assets/bee84aba-c580-4b7c-b937-c0a769c2fbb8" />

After: <img width="371" height="219" alt="image" src="https://github.com/user-attachments/assets/e027e2fc-b8e0-4767-89b4-85666c35ce86" />

Chrome: <img width="369" height="216" alt="image" src="https://github.com/user-attachments/assets/84f06989-bef6-4d30-8adb-777899514ed4" />

Fixes #7