### PR TITLE
fix: 印刷時のページ溢れを改善する

### DIFF
--- a/src/components/DocumentPage.vue
+++ b/src/components/DocumentPage.vue
@@ -6,9 +6,13 @@
 
 <style scoped>
 section {
-  width: calc(210mm - 5mm * 2);
-  height: calc(297mm - 5mm * 2);
+  width: calc(210mm);
+  height: calc(297mm - 1mm);
+  padding: var(--page-margin);
+  box-sizing: border-box;
   border: 0.1px solid transparent;
+  break-inside: avoid;
+  break-after: page;
 }
 
 /* スクリーンで表示するときは個別に余白を設定する */

--- a/src/components/SummaryContent.vue
+++ b/src/components/SummaryContent.vue
@@ -18,7 +18,7 @@
           required
         />
       </div>
-      <div>
+      <div class="submission-date">
         <span class="spacer spacer--4"></span>年<span
           class="spacer spacer--2"
         ></span
@@ -112,8 +112,8 @@ const {
 .var-field {
   display: inline-flex;
   border-bottom: 1px solid;
-  min-width: 20em;
   margin: 0 1em 0 0;
+  flex: 1 1 auto;
 
   * {
     flex: 1 1 auto;
@@ -122,6 +122,10 @@ const {
   label {
     flex: 0 0 auto;
   }
+}
+
+.submission-date {
+  white-space: nowrap;
 }
 
 .flex-root {

--- a/src/components/SummaryTable.vue
+++ b/src/components/SummaryTable.vue
@@ -447,7 +447,7 @@ const isCarryOverMatch = computed(() => {
 .summary-table {
   display: grid;
   grid-template-columns: 20pt auto repeat(2, calc(var(--num-place-width) * 9));
-  grid-template-rows: repeat(25, 28pt);
+  grid-template-rows: repeat(25, 26.5pt);
 }
 
 .text-and-field {

--- a/src/index.html
+++ b/src/index.html
@@ -15,6 +15,7 @@
     <style>
       @page {
         size: A4 portrait;
+        margin: 0 !important;
       }
 
       * {
@@ -22,6 +23,7 @@
       }
 
       :root {
+        --page-margin: 10mm;
         font-family: var(--font-family-serif);
         font-size: 10pt;
         line-height: 10pt;
@@ -38,7 +40,7 @@
       html,
       body,
       #app {
-        width: 100%;
+        width: 210mm;
         height: 100%;
         margin: 0;
       }


### PR DESCRIPTION
主にSafariで表示崩れが起きる問題を改善します。そのほかのブラウザでも、[印刷時のヘッダー・フッターの表示を抑止する](https://stackoverflow.com/questions/8228088/remove-header-and-footer-from-window-print)ことで、印刷時のレイアウトの調整の手間を減らします。

Safariの印刷ダイアログの挙動はかなりbuggyに思える点があり、完全な動作ができているわけではないような気がしますが、ないよりマシではないかと考えています……

Chrome:

<img width="1014" height="672" alt="image" src="https://github.com/user-attachments/assets/12f06269-a720-4ec6-a173-e42bad6b0b42" />

Firefox:

<img width="759" height="761" alt="image" src="https://github.com/user-attachments/assets/a2b7c296-043e-4c5d-8102-6d71bfdfa0eb" />

Safari:（印刷プレビューではページ余白が反映されないが、書き出すと正しくレンダリングされる。ただしブラウザ内のエミュレーションでは再現しない表示崩れあり）

<img width="1036" height="869" alt="image" src="https://github.com/user-attachments/assets/76df0eb0-951f-4fdd-9218-45e46552fd29" />

<img width="1202" height="486" alt="image" src="https://github.com/user-attachments/assets/4c5d7b33-b40f-40dc-b196-24ab074d6e01" />

